### PR TITLE
Upgrade to ppx_deriving 5.0 & ppxlib

### DIFF
--- a/src/Visitors.ml
+++ b/src/Visitors.ml
@@ -1,7 +1,6 @@
 open VisitorsString
 open VisitorsList
 open Ppxlib
-open Longident
 open List
 open Asttypes
 open Parsetree
@@ -933,7 +932,7 @@ let rec visit_type (env_in_scope : bool) (ty : core_type) : expression =
                polymorphic manner. The function [X.poly], applied to a type
                variable [formal], tells how it should be treated. *)
             (* The regularity check is applied only to [mono] parameters. *)
-            check_regularity ty.ptyp_loc (last_exn tycon) formals tys;
+            check_regularity ty.ptyp_loc (Longident.last_exn tycon) formals tys;
             (* The visitor method should be applied to the visitor functions
                associated with the subset of [tys] that corresponds to [poly]
                variables. *)

--- a/src/Visitors.ml
+++ b/src/Visitors.ml
@@ -1,11 +1,12 @@
 open VisitorsString
 open VisitorsList
+open Ppxlib
 open Longident
 open List
 open Asttypes
 open Parsetree
 open Ast_helper
-open Ast_convenience
+open Ppx_deriving.Ast_convenience
 open Ppx_deriving
 open VisitorsPlugin
 open VisitorsCompatibility
@@ -197,7 +198,7 @@ let datacon_modified_name (cd : constructor_declaration) : datacon =
 
 let tycon_visitor_method : tycon_visitor_method =
   fun (_, attrs, tycon) ->
-    X.visit_prefix ^ tycon_modified_name attrs (Longident.last tycon)
+    X.visit_prefix ^ tycon_modified_name attrs (Longident.last_exn tycon)
 
 (* Step 2 -- protect against name clashes. *)
 
@@ -667,7 +668,7 @@ let alias (x : variable) (ps : patterns) : patterns =
   | Endo ->
       assert (arity = 1);
       map (fun p ->
-        Pat.alias p (Location.mknoloc x)
+        Pat.alias p (Ocaml_common.Location.mknoloc x)
       ) ps
   | _ ->
       ps
@@ -932,7 +933,7 @@ let rec visit_type (env_in_scope : bool) (ty : core_type) : expression =
                polymorphic manner. The function [X.poly], applied to a type
                variable [formal], tells how it should be treated. *)
             (* The regularity check is applied only to [mono] parameters. *)
-            check_regularity ty.ptyp_loc (last tycon) formals tys;
+            check_regularity ty.ptyp_loc (last_exn tycon) formals tys;
             (* The visitor method should be applied to the visitor functions
                associated with the subset of [tys] that corresponds to [poly]
                variables. *)

--- a/src/VisitorsAnalysis.ml
+++ b/src/VisitorsAnalysis.ml
@@ -1,3 +1,4 @@
+open Ppxlib
 open Result
 open Longident
 open Asttypes
@@ -34,9 +35,9 @@ type classification =
 
 let classify (s : string) : classification =
   let lexbuf = Lexing.from_string s in
-  let backup = !Location.formatter_for_warnings in
+  let backup = !Ocaml_common.Location.formatter_for_warnings in
   let null = Format.formatter_of_buffer (Buffer.create 0) in
-  Location.formatter_for_warnings := null;
+  Ocaml_common.Location.formatter_for_warnings := null;
   let result = try
       let token1 = Lexer.token lexbuf in
       let token2 = Lexer.token lexbuf in
@@ -50,7 +51,7 @@ let classify (s : string) : classification =
     with Lexer.Error _ ->
       OTHER
   in
-  Location.formatter_for_warnings := backup;
+  Ocaml_common.Location.formatter_for_warnings := backup;
   result
 
 (* -------------------------------------------------------------------------- *)
@@ -81,7 +82,7 @@ let parse s =
 
 let is_valid_mod_longident (m : string) : bool =
   String.length m > 0 &&
-  let ms = Longident.flatten (parse m) in
+  let ms = Longident.flatten_exn (parse m) in
   List.for_all (fun m -> classify m = UIDENT) ms
 
 (* -------------------------------------------------------------------------- *)
@@ -95,7 +96,7 @@ let is_valid_class_longident (m : string) : bool =
   | Lident c ->
       classify c = LIDENT
   | Ldot (m, c) ->
-      List.for_all (fun m -> classify m = UIDENT) (Longident.flatten m) &&
+      List.for_all (fun m -> classify m = UIDENT) (Longident.flatten_exn m) &&
       classify c = LIDENT
   | Lapply _ ->
       assert false (* this cannot happen *)

--- a/src/VisitorsAnalysis.ml
+++ b/src/VisitorsAnalysis.ml
@@ -1,6 +1,5 @@
 open Ppxlib
 open Result
-open Longident
 open Asttypes
 open Parsetree
 open Ast_helper

--- a/src/VisitorsCompatibility.cppo.ml
+++ b/src/VisitorsCompatibility.cppo.ml
@@ -1,4 +1,5 @@
 let mknoloc = Location.mknoloc
+open Ppxlib
 open Asttypes
 open Parsetree
 open Ast_helper
@@ -8,10 +9,6 @@ open Ast_helper
    construct it (that is, we generate code). This module gathers the ugly bits
    whose definition varies depending on the version of OCaml that we are
    working with. *)
-
-#if OCAML_VERSION < (4, 03, 0)
-#define Nolabel ""
-#endif
 
 (* Constructing an arrow type. *)
 
@@ -26,11 +23,7 @@ let plambda (p : pattern) (e : expression) : expression =
 (* Constructing a string literal. *)
 
 let const_string (w : string) =
-#if OCAML_VERSION < (4, 03, 0)
-  Const_string (w, None)
-#else
   Const.string w
-#endif
 
 (* [ld_label] and [ld_ty] extract a label and type out of an OCaml record label
    declaration. *)
@@ -58,9 +51,6 @@ type data_constructor_variety =
   | DataInlineRecord of label list * core_type list
 
 let data_constructor_variety (cd : constructor_declaration) =
-  #if OCAML_VERSION < (4, 03, 0)
-    DataTraditional cd.pcd_args
-  #else
     match cd.pcd_args with
     (* A traditional data constructor. *)
     | Pcstr_tuple tys ->
@@ -68,7 +58,6 @@ let data_constructor_variety (cd : constructor_declaration) =
     (* An ``inline record'' data constructor. *)
     | Pcstr_record lds ->
         DataInlineRecord (ld_labels lds, ld_tys lds)
-  #endif
 
 (* Between OCaml 4.04 and OCaml 4.05, the types of several functions in [Ast_helper]
    have changed. They used to take arguments of type [string], and now take arguments

--- a/src/VisitorsCompatibility.ml
+++ b/src/VisitorsCompatibility.ml
@@ -65,25 +65,13 @@ let data_constructor_variety (cd : constructor_declaration) =
    [Typ.poly], [Exp.send], [Exp.newtype], [Ctf.val_], [Ctf.method_], [Cf.inherit_].  *)
 
 type str =
-  #if OCAML_VERSION < (4, 05, 0)
-    string
-  #else
-    string Location.loc
-  #endif
+  string Location.loc
 
 let string2str (s : string) : str =
-  #if OCAML_VERSION < (4, 05, 0)
-    s
-  #else
-    mknoloc s
-  #endif
+  mknoloc s
 
 let str2string (s : str) : string =
-  #if OCAML_VERSION < (4, 05, 0)
-    s
-  #else
-    s.txt
-  #endif
+  s.txt
 
 let typ_poly (tyvars : string list) (cty : core_type) : core_type =
   Typ.poly (List.map string2str tyvars) cty
@@ -103,43 +91,17 @@ let quantifiers qs : string list =
    changed from [(string loc * attributes * core_type) list] in OCaml 4.05 to
                 [object_field                          list] in OCaml 4.06. *)
 
-
-#if OCAML_VERSION < (4, 06, 0)
-type object_field =
-  str * attributes * core_type
-#endif
-
 let object_field_to_core_type (field : object_field) : core_type =
-  #if OCAML_VERSION < (4, 06, 0)
-    match field with
-    | (_, _, ty)      -> ty
-  #elif OCAML_VERSION < (4, 08, 0)
-    match field with
-    | Otag (_, _, ty) -> ty
-    | Oinherit ty     -> ty
-    (* this may seem nonsensical, but (so far) is used only in the
-       function [occurs_type], where we do not care what the types
-       mean *)
-  #else
-    match field.pof_desc with
-    | Otag (_, ty)  -> ty
-    | Oinherit ty   -> ty
-  #endif
+  match field.pof_desc with
+  | Otag (_, ty)  -> ty
+  | Oinherit ty   -> ty
 
 let row_field_to_core_types (field : row_field) : core_type list =
-  #if OCAML_VERSION < (4, 08, 0)
-  match field with
-  | Rtag (_, _, _, tys) ->
-      tys
-  | Rinherit ty ->
-      [ ty ]
-  #else
   match field.prf_desc with
   | Rtag (_, _, tys) ->
       tys
   | Rinherit ty ->
       [ ty ]
-  #endif
 
 (* -------------------------------------------------------------------------- *)
 
@@ -153,8 +115,4 @@ let row_field_to_core_types (field : row_field) : core_type list =
 let floating (s : string) (items : structure) : structure_item =
   let name = mknoloc s
   and payload = PStr items in
-  #if OCAML_VERSION < (4, 08, 0)
-  Str.attribute (name, payload)
-  #else
   Str.attribute (Attr.mk name payload)
-  #endif

--- a/src/VisitorsGeneration.ml
+++ b/src/VisitorsGeneration.ml
@@ -1,5 +1,5 @@
+let stdlib_compare = compare
 open Ppxlib
-open Longident
 let mknoloc = Ocaml_common.Location.mknoloc
 open Asttypes
 open Parsetree
@@ -518,7 +518,7 @@ end = struct
        a virtual method declaration to be generated several times. In fact,
        OCaml supports this, but it looks tidier if we remove duplicates. *)
     let virtual_methods, concrete_methods = List.partition is_virtual methods in
-    let cmp meth1 meth2 = Stdlib.compare (method_name meth1) (method_name meth2) in
+    let cmp meth1 meth2 = stdlib_compare (method_name meth1) (method_name meth2) in
     let virtual_methods = VisitorsList.weed cmp virtual_methods in
     let methods = virtual_methods @ concrete_methods in
     List.map meth2cf methods

--- a/src/VisitorsGeneration.ml
+++ b/src/VisitorsGeneration.ml
@@ -1,9 +1,10 @@
+open Ppxlib
 open Longident
-let mknoloc = Location.mknoloc
+let mknoloc = Ocaml_common.Location.mknoloc
 open Asttypes
 open Parsetree
 open Ast_helper
-open Ast_convenience
+open Ppx_deriving.Ast_convenience
 open VisitorsList
 open VisitorsAnalysis
 open VisitorsCompatibility
@@ -517,7 +518,7 @@ end = struct
        a virtual method declaration to be generated several times. In fact,
        OCaml supports this, but it looks tidier if we remove duplicates. *)
     let virtual_methods, concrete_methods = List.partition is_virtual methods in
-    let cmp meth1 meth2 = compare (method_name meth1) (method_name meth2) in
+    let cmp meth1 meth2 = Stdlib.compare (method_name meth1) (method_name meth2) in
     let virtual_methods = VisitorsList.weed cmp virtual_methods in
     let methods = virtual_methods @ concrete_methods in
     List.map meth2cf methods
@@ -573,7 +574,7 @@ end = struct
     ref []
 
   let warning loc msg =
-    warnings := Ast_mapper.attribute_of_warning loc msg :: !warnings
+    warnings := attribute_of_warning loc msg :: !warnings
 
   let warning loc format =
     Printf.ksprintf (warning loc) format

--- a/src/VisitorsList.ml
+++ b/src/VisitorsList.ml
@@ -1,3 +1,4 @@
+let stdlib_compare = compare
 open List
 
 (* [last xs] returns the last element of the nonempty list [xs]. *)
@@ -71,7 +72,7 @@ let rec uniq1 cmp x ys =
       []
   | y :: ys ->
       if cmp x y = 0 then
-        uniq1 compare x ys
+        uniq1 stdlib_compare x ys
       else
         y :: uniq1 cmp y ys
 

--- a/src/VisitorsSettings.ml
+++ b/src/VisitorsSettings.ml
@@ -2,6 +2,7 @@ open Result
 open VisitorsString
 open List
 let sprintf = Printf.sprintf
+open Ppxlib
 open Parsetree
 open Ppx_deriving
 open VisitorsPlugin

--- a/src/dune
+++ b/src/dune
@@ -7,11 +7,6 @@
   (ppx_runtime_libraries visitors.runtime)
 )
 
-(rule
-  (targets VisitorsCompatibility.ml)
-  (deps VisitorsCompatibility.cppo.ml)
-  (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))
-
 (env
   (dev (flags
     :standard

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
   (public_name visitors.ppx)
   (synopsis "Compile-time support for generating visitors")
   (kind ppx_deriver)
-  (libraries result compiler-libs.common ppx_tools ppx_deriving.api)
+  (libraries result compiler-libs.common ppxlib ppx_deriving.api)
   (ppx_runtime_libraries visitors.runtime)
 )
 

--- a/visitors.opam
+++ b/visitors.opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3" }
   "cppo" {build}
-  "ppx_tools"
+  "ppxlib"
   "ppx_deriving" {>= "4.4"}
   "result"
   "dune" {>= "2.0"}

--- a/visitors.opam
+++ b/visitors.opam
@@ -10,10 +10,10 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3" }
+  "ocaml" {>= "4.05.0" }
   "cppo" {build}
   "ppxlib" {>= "0.9.0"}
-  "ppx_deriving" {>= "4.4"}
+  "ppx_deriving" {>= "5.0"}
   "result"
   "dune" {>= "2.0"}
 ]

--- a/visitors.opam
+++ b/visitors.opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3" }
   "cppo" {build}
-  "ppxlib"
+  "ppxlib" {>= "0.9.0"}
   "ppx_deriving" {>= "4.4"}
   "result"
   "dune" {>= "2.0"}


### PR DESCRIPTION
@fpottier I don't have any access to the INRIA gitlab (anymore), so if that's ok for you to do it here, here is a PR to upgrade `visitors` to `ppx_deriving 5.0` (which now uses `ppxlib` instead of `ppx_tools`).

As an added bonus this will work out-of-the-box from ppxlib 0.9 to at least ppxlib 0.19 (latest) and includes the OCaml 4.12 support.

Feel free to take and modify any commit as you like.

-----

*Side note: I may have one question though: is it normal that `dune build` (without any arguments) takes forever? I tried it on the master branch as well and I still got the same behaviour*